### PR TITLE
Drop HHVM and use the build matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,13 @@
 language: php
-php:
-  - 7.1
-  - 7.2
-  - hhvm
-  - nightly
+sudo: false
 
 matrix:
-    allow_failures:
-      - php: hhvm
-      - php: nightly
+  fast_finish: true
+  include:
+    - php: 7.1
+    - php: 7.2
+    - php: nightly
+  allow_failures:
+    - php: nightly
+
 script: "composer install && phpunit tests && php example.php"


### PR DESCRIPTION
HHVM LTS 3.24 is the last version to support PHP 5 compatibility
third paragraph states "HHVM will not aim to target PHP7" and further down "We do not intend to be the runtime of choice for folks with pure PHP7 code." (just HACK)
https://hhvm.com/blog/2017/09/18/the-future-of-hhvm.html

Use build matrix
use sudo false for faster container based testing when sudo is not required for the build